### PR TITLE
use 'comparison' validator on 'on_date' attribute & passing test suite

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -23,6 +23,7 @@ class Transaction < ApplicationRecord
   validates_presence_of :mode, message: "must be selected"
   #on_date
   validates_presence_of  :on_date, message: "must be selected"
+  validates_comparison_of :on_date, less_than_or_equal_to: Date.today, message: "cannot be in the future", if: :will_save_change_to_on_date?
   #amount
   validates_presence_of :amount, :recipe_no, message: "cannot be blank"
   validates_numericality_of :amount, :recipe_no, only_integer: true, message: "must be a number"
@@ -32,14 +33,6 @@ class Transaction < ApplicationRecord
 
   # * Custom Validations
   validate :amount_should_be_less_than_the_balance, if: :will_save_change_to_amount?
-
-  validate :on_date_must_not_be_in_future, if: :will_save_change_to_on_date?
-
-  def on_date_must_not_be_in_future
-    if self.on_date.present? && (self.on_date > Date.today)
-      errors.add(:on_date, "cannot be in the future")
-    end
-  end
 
   def amount_should_be_less_than_the_balance
     if self.persisted?

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Transaction, type: :model do
             it "must have a valid date" do
                 expect(subject.on_date).to be_an_instance_of(Date)
             end
+
+            it "should be less than or equal to the current date" do
+                subject.on_date = today
+                subject.validate
+                expect(subject.errors[:on_date]).to_not include("cannot be in the future")
+            end
+
+            it "should raise error for future dates" do
+                subject.on_date = Faker::Date.forward
+                subject.validate
+                expect(subject.errors[:on_date]).to include("cannot be in the future")
+            end
         end
 
         context "recipe_no" do
@@ -43,24 +55,6 @@ RSpec.describe Transaction, type: :model do
     end
 
     context "custom validation method" do
-        context "#on_date_must_not_be_in_future" do
-            it "on_date value should not be nil" do
-                expect(subject.on_date.present?).to be_truthy
-            end
-
-            it "must raise error for future dates" do
-                subject.on_date = Faker::Date.forward
-                subject.validate
-                expect(subject.errors[:on_date]).to include("cannot be in the future")
-            end
-
-            it "must pass for present or past dates" do
-                subject.on_date = today
-                subject.validate
-                expect(subject.errors[:on_date]).to_not include("cannot be in the future")
-            end
-        end
-
         context "#amount_should_be_less_than_the_balance" do
             it "amount value should not be nil" do
                 expect(subject.amount.present?).to be_truthy


### PR DESCRIPTION
Rails 7 added a new validator method called 'comparison' that compares the attributes' value to the value provided.

We will use this method instead of using a custom validation method. They both test the same thing and achieve the same result but by using the validator method provided by rails we can be assured that the code is less prone to errors and much more readable.

Changes to the test suite have been made accordingly.