### PR TITLE
remove 'presence' validation from all the attributes that has 'numericality' validation

### DIFF
--- a/app/models/concerns/i_t_s_validation.rb
+++ b/app/models/concerns/i_t_s_validation.rb
@@ -2,7 +2,6 @@ module ITSValidation
     extend ActiveSupport::Concern
 
     included do
-        validates_presence_of :its, message: "cannot be blank"
         validates_numericality_of :its, only_integer: true, message: "must be a number"
         validates_numericality_of :its, in: 10000000..99999999, message: "is invalid"
         validates_uniqueness_of :its, message: "has already been registered"

--- a/app/models/sabeel.rb
+++ b/app/models/sabeel.rb
@@ -28,7 +28,7 @@ class Sabeel < ApplicationRecord
   # hof_name
   validates_uniqueness_of :hof_name, scope: :its, message: 'has already been registered with this ITS number'
   # apartment
-  validates_presence_of :apartment, :flat_no, :mobile, :hof_name, message: 'cannot be blank'
+  validates_presence_of :apartment, :hof_name, message: 'cannot be blank'
   # Flat No
   validates_numericality_of :flat_no, only_integer: true, message: 'must be a number'
   validates_numericality_of :flat_no, greater_than: 0, message: 'must be greater than 0'

--- a/app/models/thaali_takhmeen.rb
+++ b/app/models/thaali_takhmeen.rb
@@ -34,7 +34,7 @@ class ThaaliTakhmeen < ApplicationRecord
   validates_numericality_of :number, :total, greater_than: 0, message: "must be greater than 0"
   #number
   validates_uniqueness_of :number, scope: :year, message: "has already been taken for the selected year"
-  validates_presence_of :number, :size, :year, :total, :paid, message: "cannot be blank"
+  validates_presence_of :size, message: "cannot be blank"
   #year
   validates_uniqueness_of :year, scope: :sabeel_id, message: "sabeel is already taking thaali for selected year"
   validates_numericality_of :year, less_than_or_equal_to: $active_takhmeen, message: "must be less than or equal to #{$active_takhmeen}"

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -25,7 +25,6 @@ class Transaction < ApplicationRecord
   validates_presence_of  :on_date, message: "must be selected"
   validates_comparison_of :on_date, less_than_or_equal_to: Date.today, message: "cannot be in the future", if: :will_save_change_to_on_date?
   #amount
-  validates_presence_of :amount, :recipe_no, message: "cannot be blank"
   validates_numericality_of :amount, :recipe_no, only_integer: true, message: "must be a number"
   validates_numericality_of :amount, :recipe_no, greater_than: 0, message: "must be greater than 0"
   # recipe no

--- a/spec/models/sabeel_spec.rb
+++ b/spec/models/sabeel_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Sabeel, :type => :model do
             it { should validate_numericality_of(:its).is_in(10000000..99999999).with_message("is invalid") }
 
             it { should validate_uniqueness_of(:its).with_message("has already been registered") }
-
-            it { should validate_presence_of(:its).with_message("cannot be blank") }
         end
 
         context "email" do
@@ -43,8 +41,6 @@ RSpec.describe Sabeel, :type => :model do
         context "flat_no" do
             it { should validate_numericality_of(:flat_no).only_integer.with_message("must be a number") }
 
-            it { should validate_presence_of(:flat_no).with_message("cannot be blank") }
-
             it { should validate_numericality_of(:flat_no).is_greater_than(0).with_message("must be greater than 0") }
         end
 
@@ -52,8 +48,6 @@ RSpec.describe Sabeel, :type => :model do
             it { should validate_numericality_of(:mobile).only_integer.with_message("must be a number") }
 
             it { should validate_numericality_of(:mobile).is_in(1000000000..9999999999).with_message("is in invalid format") }
-
-            it { should validate_presence_of(:mobile).with_message("cannot be blank") }
         end
     end
 

--- a/spec/models/thaali_takhmeen_spec.rb
+++ b/spec/models/thaali_takhmeen_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ThaaliTakhmeen, type: :model do
 
         context "number" do
             it { should validate_numericality_of(:number).only_integer.with_message("must be a number") }
-            it { should validate_presence_of(:number).with_message("cannot be blank") }
             it { should validate_numericality_of(:number).is_greater_than(0).with_message("must be greater than 0") }
             it { should validate_uniqueness_of(:number).scoped_to(:year).with_message("has already been taken for the selected year") }
         end
@@ -28,20 +27,17 @@ RSpec.describe ThaaliTakhmeen, type: :model do
         end
 
         context "year" do
-            it { should validate_presence_of(:year).with_message("cannot be blank") }
             it { should validate_numericality_of(:year).only_integer.with_message("must be a number") }
             it { should validate_numericality_of(:year).is_less_than_or_equal_to($active_takhmeen).with_message("must be less than or equal to #{$active_takhmeen}") }
             it { should validate_uniqueness_of(:year).scoped_to(:sabeel_id).with_message("sabeel is already taking thaali for selected year") }
         end
 
         context "total" do
-            it { should validate_presence_of(:total).with_message("cannot be blank") }
             it { should validate_numericality_of(:total).only_integer.with_message("must be a number") }
             it { should validate_numericality_of(:total).is_greater_than(0).with_message("must be greater than 0") }
         end
 
         context "paid" do
-            it { should validate_presence_of(:paid).with_message("cannot be blank") }
             it { should validate_numericality_of(:paid).only_integer.with_message("must be a number") }
             it { should validate_numericality_of(:paid).is_greater_than_or_equal_to(0) }
             it "is set to 0 by default after instance is instantiated" do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Transaction, type: :model do
         end
 
         context "amount" do
-            it { should validate_presence_of(:amount).with_message("cannot be blank") }
             it { should validate_numericality_of(:amount).only_integer.with_message("must be a number") }
             it { should validate_numericality_of(:amount).is_greater_than(0).with_message("must be greater than 0") }
         end
@@ -47,7 +46,6 @@ RSpec.describe Transaction, type: :model do
         end
 
         context "recipe_no" do
-            it { should validate_presence_of(:recipe_no).with_message("cannot be blank") }
             it { should validate_numericality_of(:recipe_no).only_integer.with_message("must be a number") }
             it { should validate_numericality_of(:recipe_no).is_greater_than(0).with_message("must be greater than 0") }
             it { should validate_uniqueness_of(:recipe_no).with_message("has already been registered") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe User, type: :model do
             it { should validate_numericality_of(:its).is_in(10000000..99999999).with_message("is invalid") }
 
             it { should validate_uniqueness_of(:its).with_message("has already been registered") }
-
-            it { should validate_presence_of(:its).with_message("cannot be blank") }
         end
 
         context "name" do


### PR DESCRIPTION
Since `numericality` validation doesn't allow `nil` values to be saved so having `presence` validation for all those attributes duplicates the testing and validation logic. 

Hence, this PR removes those `presence` validations only from those attributes that have `numericality` validation.