### PR TITLE
Set time zone

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -23,7 +23,7 @@ class Transaction < ApplicationRecord
   validates_presence_of :mode, message: "must be selected"
   #on_date
   validates_presence_of  :on_date, message: "must be selected"
-  validates_comparison_of :on_date, less_than_or_equal_to: Date.today, message: "cannot be in the future", if: :will_save_change_to_on_date?
+  validates_comparison_of :on_date, less_than_or_equal_to: Time.zone.now.to_date, message: "cannot be in the future", if: :will_save_change_to_on_date?
   #amount
   validates_numericality_of :amount, :recipe_no, only_integer: true, message: "must be a number"
   validates_numericality_of :amount, :recipe_no, greater_than: 0, message: "must be greater than 0"

--- a/spec/models/thaali_takhmeen_spec.rb
+++ b/spec/models/thaali_takhmeen_spec.rb
@@ -3,11 +3,6 @@ require "rails_helper"
 RSpec.describe ThaaliTakhmeen, type: :model do
     subject { build(:thaali_takhmeen) }
 
-    today = Date.today
-    yesterday = Date.today.prev_day
-    current_year = Date.today.year
-    next_year = today.next_year.year
-
     context "association" do
         it { should belong_to(:sabeel) }
         it { should have_many(:transactions).dependent(:destroy) }

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -3,10 +3,8 @@ require "rails_helper"
 RSpec.describe Transaction, type: :model do
     subject { build(:transaction) }
 
-    today = Date.today
-    yesterday = Date.today.prev_day
-    current_year = today.year
-    next_year = today.next_year.year
+    today = Time.zone.now.to_date
+    yesterday = today.prev_day
 
     context "assocaition" do
         subject { create(:transaction) }


### PR DESCRIPTION
This PR sets the application's time zone to "Asia/Kolkata" and returns the proper date based on the time zone set.

This eventually fixes the bug where we received a wrong validation error from the `on_date` attribute in the production. The transactions would not be created if the transactions' `on_date` value was set within the past month which is a valid value but instead, it returned this error message `On date cannot be in the future`.