### PR TITLE
🐛 Preventing flash messages from reappearing

### DIFF
--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,4 +1,4 @@
-<div id="flash" data-controller="autohide" class="z-2 position-fixed bg-primary rounded-5 fs-5 p-3 mt-4">
+<div id="flash" data-controller="autohide" data-turbo-temporary class="z-2 position-fixed bg-primary rounded-5 fs-5 p-3 mt-4">
   <% flash.each do |name, msg| %>
     <%= render_flash(name, msg) %>
   <% end %>


### PR DESCRIPTION
This PR fixes the bug which I have explained in detail [here](https://stackoverflow.com/questions/77546823/flash-message-showing-up-again-on-clicking-the-back-button-in-rails/77904101#77904101). **The flash message appeared multiple times**.

Adding the `data-turbo-temporary` attribute to the `flash` block removes it from the document before being cached. Hence, preventing it from reappearing multiple times.