### PR TITLE
🔧 upgrade `capybara`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
 end
 
 group :test do
-  gem "capybara", "~> 3.39.2"
+  gem "capybara", "~> 3.40.0"
   gem "rack_session_access"
   gem "rails-controller-testing", "~> 1.0.5"
   gem "selenium-webdriver", "~> 4.15.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
@@ -95,11 +95,11 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     cancancan (3.5.0)
-    capybara (3.39.2)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -198,7 +198,7 @@ GEM
       railties (>= 7.0.0)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -388,7 +388,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   cancancan (~> 3.5.0)
-  capybara (~> 3.39.2)
+  capybara (~> 3.40.0)
   cssbundling-rails
   debug
   dockerfile-rails (>= 1.5)


### PR DESCRIPTION
This PR addresses the ```Rack::Handler is deprecated and replaced by Rackup::Handler``` error when running the rspec tests.

- Upgrade the `capybara` gem from version `3.39.2` to `3.40`.