### PR TITLE
Remove `active_record_union` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby "~> 3.3.6"
 
 gem "rails", "~> 8.0.1"
 
-gem "active_record_union", github: "brianhempel/active_record_union", branch: "master"
 gem "bcrypt", "~> 3.1.20"
 gem "bootsnap", require: false
 gem "cancancan", "~> 3.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/brianhempel/active_record_union.git
-  revision: 8ebe558709aabe039abd24e3e7dd4d4354a6de88
-  branch: master
-  specs:
-    active_record_union (1.3.0)
-      activerecord (>= 6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -401,7 +393,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_record_union!
   bcrypt (~> 3.1.20)
   bootsnap
   brakeman

--- a/app/models/concerns/active_record_relation_extensions.rb
+++ b/app/models/concerns/active_record_relation_extensions.rb
@@ -1,0 +1,8 @@
+module ActiveRecordRelationExtensions
+  refine ActiveRecord::Relation do
+    def union(q)
+      union_query = Arel::Nodes::Union.new(arel, q.arel).as(klass.table_name)
+      klass.from(union_query)
+    end
+  end
+end

--- a/app/models/sabeel.rb
+++ b/app/models/sabeel.rb
@@ -64,13 +64,4 @@ class Sabeel < ApplicationRecord
   def took_thaali? = Rails.cache.fetch("sabeel_#{id}_took_thaali?") { thaalis.exists? year: PREV_YR }
 
   def last_year_thaali_dues_cleared? = thaalis.dues_cleared_in(PREV_YR).present?
-
-  private
-
-  # class << self
-  #   def unioned(q1, q2)
-  #     union_query = Arel::Nodes::Union.new(no_thaali.arel, took_thaali.arel).as("sabeels")
-  #     from(union_query)
-  #   end
-  # end
 end

--- a/app/models/sabeel.rb
+++ b/app/models/sabeel.rb
@@ -27,6 +27,7 @@ class Sabeel < ApplicationRecord
   include ITSValidation
   include NameValidation
 
+  using ActiveRecordRelationExtensions
   using ArrayExtensions
 
   # * Enums
@@ -63,4 +64,13 @@ class Sabeel < ApplicationRecord
   def took_thaali? = Rails.cache.fetch("sabeel_#{id}_took_thaali?") { thaalis.exists? year: PREV_YR }
 
   def last_year_thaali_dues_cleared? = thaalis.dues_cleared_in(PREV_YR).present?
+
+  private
+
+  # class << self
+  #   def unioned(q1, q2)
+  #     union_query = Arel::Nodes::Union.new(no_thaali.arel, took_thaali.arel).as("sabeels")
+  #     from(union_query)
+  #   end
+  # end
 end

--- a/app/models/thaali.rb
+++ b/app/models/thaali.rb
@@ -23,6 +23,7 @@ class Thaali < ApplicationRecord
 
   def sluggables = [year, number]
 
+  using ActiveRecordRelationExtensions
   using ArrayExtensions
 
   # * Enums


### PR DESCRIPTION
This resolves [this](https://github.com/JuzerShakir/fmb/issues/62) issue.

We used [`refinements`](https://huzefabiyawarwala.medium.com/how-to-safely-monkey-patch-rubys-string-class-using-refinements-without-affecting-the-entire-5a7dd41bb6e6) to extend the `ActiveRecord::Relation` class and add a `union` method to it which performs SQL `union` to our queries.

Since the dependency we were [using](https://github.com/brianhempel/active_record_union) is no longer compatible with  >= Rails v8, it was time to implement our logic for the `union` method. 

After merging this PR, this should be able to be deployed successfully in production.