### PR TITLE
Refactor `number_to_human`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     builder (3.3.0)
     cancancan (3.6.1)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ module ApplicationHelper
 
   def add_rupees_symbol_to(amount, delimiter: false)
     content_tag :span do
-      fa_gen(delimiter ? number_with_delimiter(amount) : number_to_social(amount),
+      fa_gen(delimiter ? number_with_delimiter(amount) : amount.to_human,
         "fa-indian-rupee-sign fa-xs")
     end
   end
@@ -37,15 +37,6 @@ module ApplicationHelper
     when "notice" then "exclamation"
     when "alert" then "xmark"
     end
-  end
-
-  def number_to_social(number)
-    number_to_human(number,
-      precision: 1,
-      round_mode: :down,
-      significant: false,
-      format: "%n%u",
-      units: {thousand: "K", million: "M"})
   end
 
   def set_url_params_for(url)

--- a/config/initializers/numeric.rb
+++ b/config/initializers/numeric.rb
@@ -1,0 +1,8 @@
+class Numeric
+  include ActionView::Helpers::NumberHelper
+
+  def to_human(**kwargs)
+    defaults = {precision: 1, round_mode: :down, significant: false, format: "%n%u", units: {thousand: "K", million: "M"}}
+    number_to_human(self, defaults.merge(**kwargs))
+  end
+end

--- a/spec/support/matchers/have_humanized_number_matcher.rb
+++ b/spec/support/matchers/have_humanized_number_matcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec::Matchers.define :have_humanized_number do |expected_value|
-  humanized_number = number_to_human(expected_value, precision: 1, round_mode: :down, significant: false, format: "%n%u", units: {thousand: "K", million: "M"})
+  humanized_number = expected_value.to_human
 
   match do
     _1.body.include? humanized_number


### PR DESCRIPTION
Refactored `options` hash passed into the `number_to_human` method.

- Opened the `Numeric` class and added a wrapper method `to_human` to the `number_to_human` method. 
- Set up `options` hash with default key-value pairs.
- You can override the default values of a key by passing a keyword argument to the `to_human` method.
- Use the `to_human` method in the Views and Test suite. This will keep the logic in sync with the test.